### PR TITLE
Fix UTC hours & adds timer count-up mode

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -51,6 +51,10 @@ Once your library is imported, you can use its components, directives and pipes 
 <h1>
   {{title}}
 </h1>
+Timer mode:
+<countdown-timer [start]="'2017-01-01 00:00:00'"></countdown-timer>
+ 
+Countdown:
 <countdown-timer [end]="'2018-01-01 00:00:00'"></countdown-timer>
 ```
 

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -12,8 +12,12 @@ import { CountdownTimerModule }  from 'ngx-countdown-timer';
   selector: 'app',
   template: `
     <countdown-timer [end]="'2017-12-10 01:00:00'"></countdown-timer>
-    <countdown-timer [end]="'2017-10-30 01:00:00'"></countdown-timer>
-    <countdown-timer [end]="'2017-10-20 01:00:00'"></countdown-timer>
+    <countdown-timer [end]="'2018-01-01 01:00:00'"></countdown-timer>
+    <countdown-timer [end]="'2018-03-01 01:00:00'"></countdown-timer>
+    
+    <countdown-timer [start]="'2017-11-09 01:00:00'"></countdown-timer>
+    <countdown-timer [start]="'2017-10-30 01:00:00'"></countdown-timer>
+    <countdown-timer [start]="'2017-10-20 01:00:00'"></countdown-timer>
     `
 })
 class AppComponent {}

--- a/src/countdown-timer.component.ts
+++ b/src/countdown-timer.component.ts
@@ -6,6 +6,7 @@ import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 })
 export class CountdownTimer implements OnInit, OnDestroy{
  
+  @Input() start;
   @Input() end;
   displayTime: string;
   timer: any;
@@ -14,8 +15,12 @@ export class CountdownTimer implements OnInit, OnDestroy{
   }
 
   ngOnInit(): void {
-    this.timer = setInterval(() => { 
-        this.displayTime = this.getTimeDiff(this.end) 
+    this.timer = setInterval(() => {
+        if (this.start) {
+            this.displayTime = this.getTimeDiff(this.start, true);
+        } else {
+            this.displayTime = this.getTimeDiff(this.end);
+        }
       }, 1000);
   }
 
@@ -23,7 +28,7 @@ export class CountdownTimer implements OnInit, OnDestroy{
     clearInterval(this.timer);
   }
 
-  private getTimeDiff( datetime ) {
+  private getTimeDiff( datetime, useAsTimer = false ) {
       datetime = new Date( datetime ).getTime();
       var now = new Date().getTime();
   
@@ -33,6 +38,9 @@ export class CountdownTimer implements OnInit, OnDestroy{
       }
 
       var milisec_diff = datetime - now;
+      if (useAsTimer) {
+          milisec_diff = now - datetime;
+      }
       var days = Math.floor(milisec_diff / 1000 / 60 / (60 * 24));
       var date_diff = new Date( milisec_diff );
       var day_string = (days) ? this.twoDigit(days) + ":" : "";

--- a/src/countdown-timer.component.ts
+++ b/src/countdown-timer.component.ts
@@ -36,8 +36,9 @@ export class CountdownTimer implements OnInit, OnDestroy{
       var days = Math.floor(milisec_diff / 1000 / 60 / (60 * 24));
       var date_diff = new Date( milisec_diff );
       var day_string = (days) ? this.twoDigit(days) + ":" : "";
-      
-      return day_string + this.twoDigit(date_diff.getHours()) +
+
+      // Date() takes a UTC timestamp – getHours() gets hours in local time not in UTC. therefore we have to use getUTCHours()
+      return day_string + this.twoDigit(date_diff.getUTCHours()) +
          ":" + this.twoDigit(date_diff.getMinutes()) + ":" 
          + this.twoDigit(date_diff.getSeconds());
   }


### PR DESCRIPTION
I added a property "start" which when set makes the timer count up (instead of down).

Also I noticed that the hour printed on the screen is one off, which is most likely due to the fact that Date objects are UTC and getHours() is not, see: https://stackoverflow.com/questions/18021098/javascript-date-difference-one-hour-too-much.